### PR TITLE
Matt/2.x.x/suggest

### DIFF
--- a/package/lib/index.js
+++ b/package/lib/index.js
@@ -34,7 +34,7 @@
  */
 function suggest (incorrectName, correctName) {
   return function () {
-    throw new Error(`The function [${incorrectName}] does not exist. You probably meant to use [${correctName}].`)
+    throw new Error(`[${incorrectName}] is not a valid function. Please use [${correctName}] instead.`)
   }
 }
 
@@ -465,12 +465,6 @@ function equals (set) {
   return this.isSubset(set)
 }
 global.Set.prototype.equals = equals
-// temporary: make backwards compatible
-global.Set.prototype.equal = equals
-
-// global.Set.prototype.equal = suggest('equal', 'equals')
-global.Set.prototype.isEqual = suggest('isEqual', 'equals')
-global.Set.prototype.isEqualTo = suggest('isEqualTo', 'equals')
 
 // //////////////////////////////////////////////////////////////////////////////// //
 //                                                                                  //
@@ -977,6 +971,50 @@ function mergeRulesStrict (...rules) {
 }
 
 global.Set.mergeRulesStrict = mergeRulesStrict
+
+/**
+ * Suggest function names when user guesses a name that doesn't exist but is nonetheless unambiguous.
+ */
+const correctSetNameToIncorrectNames = new Map([
+  ['from', []],
+  ['toSet', []],
+  ['copy', ['clone']],
+  ['union', []],
+  ['intersection', ['intersect']],
+  ['difference', ['minus']],
+  ['complement', []],
+  ['symmetricDifference', ['symDiff', 'symDifference', 'symmetricDiff']],
+  ['cartesianProduct', ['prod', 'product', 'cartProd', 'cartProduct', 'cartesianProd']],
+  ['powerSet', ['powerset', 'subsets']]
+])
+const correctSetPrototypeNameToIncorrectNames = new Map([
+  ['add', ['append', 'push', 'insert']],
+  ['has', []],
+  ['rules', []],
+  ['toArray', ['array']],
+  ['any', ['anElement']],
+  ['randomElement', ['rand', 'random', 'randElement']],
+  ['isEmpty', ['empty']],
+  ['isSuperset', ['superset', 'isSupersetOf', 'supersetOf']],
+  ['isSubset', ['subset', 'isSubsetOf', 'subsetOf']],
+  ['isProperSuperset', ['properSuperset', 'isProperSupersetOf', 'properSupersetOf', 'isStrictSuperset', 'strictSuperset', 'isStrictSupersetOf', 'strictSupersetOf']],
+  ['isProperSubset', ['properSubset', 'isProperSubsetOf', 'properSubsetOf', 'isStrictSubset', 'strictSubset', 'isStrictSubsetOf', 'strictSubsetOf']],
+  ['equals', ['equal', 'isEqualTo']],
+  ['union', []],
+  ['intersect', ['intersection']],
+  ['minus', ['difference']],
+  ['symmetricDifference', ['symDiff', 'symDifference', 'symmetricDiff']],
+  ['cartesianProduct', ['prod', 'product', 'cartProd', 'cartProduct', 'cartesianProd']]
+])
+function setSuggestions (object, suggestionDict) {
+  suggestionDict.forEach((incorrectNames, correctName) => {
+    incorrectNames.forEach(incorrectName => {
+      object[incorrectName] = suggest(incorrectName, correctName)
+    })
+  })
+}
+setSuggestions(global.Set, correctSetNameToIncorrectNames)
+setSuggestions(global.Set.prototype, correctSetPrototypeNameToIncorrectNames)
 
 /**
  * Flag to indicate the presence of this polyfill

--- a/package/lib/index.js
+++ b/package/lib/index.js
@@ -30,6 +30,8 @@
 // //////////////////////////////////////////////////////////////////////////////// //
 
 /**
+ * Suggest to user which function name they should be using.
+ * Note: We should consider removing the suggest feature once migration to 2.x.x has been completed and the package has been in use for a while.
  * @private
  */
 function suggest (incorrectName, correctName) {
@@ -974,6 +976,7 @@ global.Set.mergeRulesStrict = mergeRulesStrict
 
 /**
  * Suggest function names when user guesses a name that doesn't exist but is nonetheless unambiguous.
+ * Note: We should consider removing the suggest feature once migration to 2.x.x has been completed and the package has been in use for a while.
  */
 const correctSetNameToIncorrectNames = new Map([
   ['from', []],
@@ -1006,6 +1009,7 @@ const correctSetPrototypeNameToIncorrectNames = new Map([
   ['symmetricDifference', ['symDiff', 'symDifference', 'symmetricDiff']],
   ['cartesianProduct', ['prod', 'product', 'cartProd', 'cartProduct', 'cartesianProd']]
 ])
+// Note: We should consider removing the suggest feature once migration to 2.x.x has been completed and the package has been in use for a while.
 function setSuggestions (object, suggestionDict) {
   suggestionDict.forEach((incorrectNames, correctName) => {
     incorrectNames.forEach(incorrectName => {

--- a/package/lib/index.tests.js
+++ b/package/lib/index.tests.js
@@ -40,6 +40,23 @@ function areNotEqual (set1, set2) {
 const isInt = n => Number.isInteger(n)
 const set = (...args) => new Set([...args])
 
+describe('Invalid functions', function () {
+  it('gives a suggestion if you use a wrong but unambiguous function name', function () {
+    // Set level function
+    assert.throws(function () {
+      const A = new Set([])
+      const B = new Set([])
+      Set.product(A, B)
+    }, /\[product\] is not a valid function. Please use \[cartesianProduct\] instead\./)
+    // Set prototype level function
+    assert.throws(function () {
+      const A = new Set([])
+      const B = new Set([])
+      A.isSubsetOf(B)
+    }, /\[isSubsetOf\] is not a valid function. Please use \[isSubset\] instead\./)
+  })
+})
+
 describe('Constructor', function () {
   it('has a flag to indicate the polyfill being present', function () {
     assert.isTrue(Set.__isExtended__)

--- a/package/lib/index.tests.js
+++ b/package/lib/index.tests.js
@@ -40,6 +40,7 @@ function areNotEqual (set1, set2) {
 const isInt = n => Number.isInteger(n)
 const set = (...args) => new Set([...args])
 
+// Note: We should consider removing the suggest feature once migration to 2.x.x has been completed and the package has been in use for a while.
 describe('Invalid functions', function () {
   it('gives a suggestion if you use a wrong but unambiguous function name', function () {
     // Set level function


### PR DESCRIPTION
PR for issue #24 

This implements the function suggester for people who use the wrong function name.  This is meant to make debugging easier for users.  This will also help people to migrate from version 1 to version 2 when the time comes.

Let me know what you think.